### PR TITLE
Total changes:

### DIFF
--- a/assets/components/mixedimage/css/mgr/mixedimage.css
+++ b/assets/components/mixedimage/css/mgr/mixedimage.css
@@ -8,59 +8,45 @@
 }
 
 .mixedimage .x-form-field-trigger-wrap{
-	width: 350px  !important;
 	margin-bottom: 10px;
 }
 
-.mixedimage .x-form-field-trigger-wrap input[type="text"]{
-	width: 245px  !important; 
-}
 
 .mixedimge_name{
 	color: #777;
 	font-size: 12px;
 }
 
-.x-field-trigger0-class,
-.x-field-trigger1-class,
-.x-field-trigger2-class{
-	width: 30px !important;
+.mixedimage .x-form-field-wrap .x-field-combo-btns .x-form-trigger{
 	background-color: #fff;
 	text-align: center;
 	border-left: 1px solid #e4e4e4 !important;
 }
 
-.x-field-trigger0-class:hover,
-.x-field-trigger1-class:hover,
-.x-field-trigger2-class:hover{
+.mixedimage .x-form-field-wrap .x-field-combo-btns .x-form-trigger:hover{
 	border-left-color: transparent !important;
 }
 
-.x-field-trigger0-class::before,
-.x-field-trigger1-class::before,
-.x-field-trigger2-class::before{
+.mixedimage .x-form-field-wrap .x-field-combo-btns .x-form-trigger::before{
 	right: 0px !important;
 }
 
-.x-field-trigger0-class { right: 61px !important; border-radius: 0 !important; }
+.mixedimage .x-form-field-wrap .x-field-combo-btns .x-form-trigger:first-child{
+	border-radius: 0 !important;
+}
+.mixedimage .x-form-field-wrap .x-field-combo-btns .x-form-trigger:not(:last-child):hover{
+	border-radius: 0;
+}
+
 .x-field-trigger0-class:before {content: '\f00d' !important; }
-.x-field-trigger0-class:hover {border-radius: 0;}
-
-.x-field-trigger1-class { right: 30px !important;}
 .x-field-trigger1-class:before {content: '\f1c5' !important;}
-.x-field-trigger1-class:hover {border-radius: 0;}
-
 .x-field-trigger2-class:before {content: '\f108' !important;}
 
-.x-form-field-wrap .x-form-trigger.x-field-trigger0-class,
-.x-form-field-wrap .x-form-trigger.x-field-trigger1-class,
-.x-form-field-wrap .x-form-trigger.x-field-trigger2-class{
+.mixedimage .x-form-field-wrap .x-field-combo-btns .x-form-trigger{
 	background-color: #fff;
 }
 
-.x-form-field-wrap .x-form-trigger.x-field-trigger0-class:hover,
-.x-form-field-wrap .x-form-trigger.x-field-trigger1-class:hover,
-.x-form-field-wrap .x-form-trigger.x-field-trigger2-class:hover{
+.mixedimage .x-form-field-wrap .x-field-combo-btns .x-form-trigger:hover{
 	background-color: #3697CD;
 }
 

--- a/assets/components/mixedimage/js/mgr/mixedimage.js
+++ b/assets/components/mixedimage/js/mgr/mixedimage.js
@@ -6,229 +6,304 @@ mixedimage.panel = function(config) {
     if (!config.source) {config.source = MODx.config.default_media_source;}
     if (!config.ctx) {config.ctx = 'web';}
 
-    if(config.removeFile){
-        var btn_remove = _('mixedimage.trigger_remove');
-    }else{        
-        var btn_remove = _('mixedimage.trigger_clear');
-    }
-
     Ext.apply(config,{
         border:false
         ,listeners: {}
         ,items:[{
-		    xtype: 'container' 
+            xtype: 'container' 
             ,layout: 'column'
             ,border: false   
             ,width: '98%' 
             ,id: 'mixedimage_container'+config.tvId
             ,anchorSize: {width:'98%', height:'auto'}
-    		,items: [{
-    			xtype:'container' 
-            	,hidden: true
-                ,id: 'mixedimage_media_container'+config.tvId
-                ,items: [{ 
-	    			xtype:'modx-combo-browser'
-                	,browserEl: 'modx-browser'
-	                ,TV: this
-	                ,id: 'mixedimage_media'+config.tvId
-	                ,source: config.source
-	                ,ctx_path: config.ctx_path
-                    ,openTo: config.openPath
-	                ,listeners: {
-	                    'select': function(data){
-	                    	var value = this.getValue();  
-						    Ext.getCmp('mixedimage_input'+config.tvId).setValue(value); 
-		                    Ext.get('tv'+config.tvId).dom.value = value;
-		                    Ext.get('mixedimage'+config.tvId).dom.value = value;
-
-		                    if(config.showPreview === true){
-				                var d = Ext.get('tv-image-preview-'+config.tvId);
-				                if (Ext.isEmpty(value)) {
-				                    d.update('');
-				                } else {
-				                    d.update('<img src="'+MODx.config.connectors_url+'system/phpthumb.php?w=300&h=300&aoe=0&far=0&src='+value+'&source='+config.source+'" alt="" />');
-				                }
-				            } 
-
-		                    MODx.fireResourceFormChange(); 
-	                    }
-	                }
-                }]
-    		},{
-		    	xtype: 'trigger' 
-				,name: 'mixedimage_input'+config.tvId
-				,width: 200
-        		,value: config.value
-				,id: 'mixedimage_input'+config.tvId
-				,emptyText: ''
-				,triggerConfig: {
-				    tag: 'span',
-				    cls: 'x-field-combo-btns',
-				    cn: [
-				        {tag: 'div', cls: 'x-form-trigger x-field-trigger0-class', trigger: 'clear', title: btn_remove},
-				        {tag: 'div', cls: 'x-form-trigger x-field-trigger1-class', trigger: 'manager', title: _('mixedimage.trigger_from_file_manager')},
-				        {tag: 'div', cls: 'x-form-trigger x-field-trigger2-class', trigger: 'pc', title: _('mixedimage.trigger_from_desktop')}
-					]
-				}
-				,listeners:{
-					change: function(data){
-						this.saveValue(data.el.getValue());
-					}
-				}
-				,onTriggerClick: function(event, el){
-				    // Проверяем какой триггер нажат.
-				    switch (el.getAttribute('trigger')){
-				        case 'clear': 
-		                    this.clearField(config); 
-				            break;
-				        case 'manager':
-				        	var parent = Ext.get('mixedimage_media_container'+config.tvId);
-							var elems = parent.select(".x-form-file-trigger").elements; 
-                    		elems[0].click();
-				            break;
-				        case 'pc':				            
-                    		Ext.get('mixedimage_desktop'+config.tvId+'-file').dom.click();
-				            break;
-				        default: 
-				            //alert('Нажата кнопка 3');
-				    }
-				}
-				,saveValue: function(value){  
-				    Ext.getCmp('mixedimage_input'+config.tvId).setValue(value); 
-                    Ext.get('tv'+config.tvId).dom.value = value;
-                    Ext.get('mixedimage'+config.tvId).dom.value = value;
-                    MODx.fireResourceFormChange(); 
-				    this.updateView(config);
-				}
-				,updateView: function(config){   
-					var value = Ext.get('tv'+config.tvId).dom.value;
-
-					if(config.showPreview === true){
-		                var d = Ext.get('tv-image-preview-'+config.tvId);
-		                if (Ext.isEmpty(value)) {
-		                    d.update('');
-		                } else {
-		                    d.update('<img src="'+MODx.config.connectors_url+'system/phpthumb.php?w=300&h=300&aoe=0&far=0&src='+value+'&source='+config.source+'" alt="" />');
-		                }
-		            } 
-
-				}
-				,clearField: function(config){  
-                    var value = Ext.get('tv'+config.tvId).dom.value;
-
-                    if(config.ctx_path){
-                    	value = config.ctx_path+value;
-                    }
-
-                    if(config.removeFile){
-                    	Ext.Ajax.request({
-						    url: MODx.config.assets_url+'components/mixedimage/connector.php',
-						    success: function(data){                                
-                                Ext.Msg.alert('Remove', _('mixedimage.success_removed'));
-                            }
-                            ,failure: function(data) {
-                                Ext.Msg.alert('Error', _('mixedimage.error_remove'));                                
-                                console.log(data);
-                            }
-						    ,params: { value: value, action: 'removeFile' }
-						});
-                    } 
-					Ext.getCmp('mixedimage_input'+config.tvId).setValue(''); 
-		            Ext.get('tv'+config.tvId).dom.value = '';
-		            Ext.get('mixedimage'+config.tvId).dom.value = '';
- 
-                    MODx.fireResourceFormChange(); 
-				    this.updateView(config);
-				}
-		    }]
+            ,items: this.getItems(config)
         }]
     });
 
     mixedimage.panel.superclass.constructor.call(this,config);
 
-    Ext.onReady(function(){ 
-
-    	var mixedfileform = new Ext.FormPanel({
-            id: this.uploadFormInputId
-            ,renderTo: 'modx-content'
-            ,isUpload: true
-            ,hidden: true
-            ,fileUpload: true
-            ,url: MODx.config.assets_url+'components/mixedimage/connector.php'
-            ,baseParams: {
-                action: 'browser/file/upload'
-                ,tvId: config.tvId
-                ,prefixFilename: config.prefixFilename
-                ,res_id: config.res_id
-                ,res_alias: config.res_alias
-                ,p_id: config.p_id
-                ,p_alias: config.p_alias
-                ,tv_id: config.tv_id
-                ,ms_id: config.ms_id
-                ,acceptedMIMEtypes: config.acceptedMIMEtypes
-                ,lex: config.jsonlex
-                ,ctx_path: config.ctx_path
-                //,resize: config.resize
-            }
-            ,TV: this
-            ,items: [{
-                xtype:'fileuploadfield'
-                ,TV: this
-                ,id: 'mixedimage_desktop'+config.tvId
-                ,listeners: {
-                    'fileselected': {fn:
-                        function(){
-                            var UploadField = mixedfileform.items.items[0];
-                            mixedfileform.form.baseParams.file = UploadField.getValue();
-
-                            if(!config.res_id && config.onlyEdit == 1){
-                            	Ext.Msg.alert('Error', _('mixedimage.err_save_resource'));
-                            	return;
-                            }  
-
-                            mixedfileform.form.submit({
-                                waitMsg: 'Uploading...',
-                                success: function(fp, o){
-                                    var value = o.result.message;
-                                    Ext.get('tv'+config.tvId).dom.value = value;
-                                    Ext.get('mixedimage'+config.tvId).dom.value = value;
-                                    MODx.fireResourceFormChange();
-                                    updatePreview(value);
-                                }
-                                ,failure: function(fp, o) { 
-                                    Ext.Msg.alert('Error', _('mixedimage.err_save_resource'));
-                                }
-                            });
-                        }
-                        , scope:this }
-                }
-            }]
-        })
-
-        var updatePreview = function(value){
- 
-			Ext.getCmp('mixedimage_input'+config.tvId).setValue(value); 
-
-            if(config.showPreview === true){
-                var d = Ext.get('tv-image-preview-'+config.tvId);
-                if (Ext.isEmpty(value)) {
-                    d.update('');
-                } else {
-                    d.update('<img src="'+MODx.config.connectors_url+'system/phpthumb.php?w=300&h=300&aoe=0&far=0&src='+value+'&source='+config.source+'" alt="" />');
-                }
-            }
- 
-        } 
- 
+    this.previewTpl=new Ext.XTemplate('<tpl for=".">'
+            +'<img src="'+MODx.config.connectors_url+'system/phpthumb.php?w={width}&h={height}&f=png&src={value}&source='+this.source+'" alt="" />'
+        +'</tpl>', {
+        compiled: true
     });
 
+    Ext.onReady(function(){this.loadFileForm();},this);
+    
+    this.on('onFileUploadSuccess',this.onFileUploadSuccess,this);
 };
 
 Ext.extend(mixedimage.panel,Ext.Container,{
-
-	//handler functions
-	
-
+    getItems:function(config){
+        return [this.getImageContainer(config),this.getTriggerField(config)];
+    }
+    ,getImageContainer:function(config){
+        return{
+            xtype:'container' 
+            ,hidden: true
+            ,id: 'mixedimage_media_container'+config.tvId
+            ,items: [{ 
+                xtype:'modx-combo-browser'
+                ,browserEl: 'modx-browser'
+                ,TV: this
+                ,id: 'mixedimage_media'+config.tvId
+                ,source: config.source
+                ,ctx_path: config.ctx_path
+                ,openTo: config.openPath
+                ,listeners: {
+                    'select':{fn:this.onBrowserSelect,scope:this}
+                }
+            }]
+        };
+    }
+    ,getDefaultTriggerConfig:function(config){
+        return{
+            xtype: 'mixedimage-trigger' 
+            ,name: 'mixedimage_input'+config.tvId
+            ,value: config.value
+            ,id: 'mixedimage_input'+config.tvId
+            ,emptyText: ''
+            ,tvId: config.tvId
+            ,source: config.source
+            ,showPreview: config.showPreview
+            ,ctx_path: config.ctx_path
+            ,removeFile: config.removeFile
+            ,listeners:{
+                change: function(data){
+                    this.saveValue(data.el.getValue());
+                }
+            }
+        };
+    }
+    ,getTriggerField:function(config){
+        return this.getDefaultTriggerConfig(config);
+    }
+    ,getCustomPath:function(){
+        return this.custompath||'';
+    }
+    ,onFileUploadSuccess:function(r){
+        
+    }
+    ,onBrowserSelect:function(data,field){
+        var value = field.getValue();
+        this.setValue(value);
+    }
+    ,setValue:function(value){
+        this.getInput().setValue(value); 
+        this.getTVField().dom.value = value;
+        this.el.dom.value = value;
+        this.updatePreview(value);
+        MODx.fireResourceFormChange();
+    }
+    ,getInput:function(){
+        this.input = this.input||Ext.getCmp('mixedimage_input'+this.tvId);
+        return this.input;
+    }
+    ,getTVField:function(){
+        this.tvfield = this.tvfield||Ext.get('tv'+this.tvId);
+        return this.tvfield;
+    }
+    ,getPreview:function(){
+        this.preview = this.preview||Ext.get('tv-image-preview-'+this.tvId);
+        return this.preview;
+    }
+    ,updatePreview:function(value){
+        if(this.showPreview === true){
+            var d = this.getPreview();
+            var content = '';
+            if(!Ext.isEmpty(value))content = this.previewTpl.apply({width:200,height:100,value:value});
+            d.update(content);
+        }
+    }
+    ,loadFileForm:function(){
+        this.fileform=new mixedimage.fileform({
+            id: this.uploadFormInputId
+            ,renderTo: 'modx-content'
+            ,TV:this
+        });
+        this.fileform.on('onFileUploadSuccess',function(r){ this.fireEvent('onFileUploadSuccess',r);},this);
+    }
 });
-
 Ext.reg('mixedimage-panel',mixedimage.panel); 
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+mixedimage.fileform = function(config){
+    config = config||{};
+    Ext.applyIf(config,{
+        isUpload: true
+        ,hidden: true
+        ,fileUpload: true
+        ,url: MODx.config.assets_url+'components/mixedimage/connector.php'
+        ,baseParams:this.getBaseParams(config)
+        ,items:this.getItems(config)
+    });
+    mixedimage.fileform.superclass.constructor.call(this,config);
+};
+Ext.extend(mixedimage.fileform,Ext.FormPanel,{
+    getBaseParams:function(config){
+        return {
+            action: 'browser/file/upload'
+            ,tvId: config.TV.tvId
+            ,prefixFilename: config.TV.prefixFilename
+            ,res_id: config.TV.res_id
+            ,res_alias: config.TV.res_alias
+            ,p_id: config.TV.p_id
+            ,p_alias: config.TV.p_alias
+            ,tv_id: config.TV.tv_id
+            ,ms_id: config.TV.ms_id
+            ,acceptedMIMEtypes: config.TV.acceptedMIMEtypes
+            ,lex: config.TV.jsonlex
+            ,ctx_path: config.TV.ctx_path
+            //,resize: config.resize
+        };
+    }
+    ,getItems:function(config){
+        var items=[];
+        items.push(
+            {
+                xtype:'fileuploadfield'
+                ,panel: config.TV
+                ,id: 'mixedimage_desktop'+config.TV.tvId
+                ,listeners: {
+                    'fileselected': {fn:this.onFileSelected,scope:this}
+                }
+            }
+        );
+        return items;
+    }
+    ,onFileSelected:function(field,value){
+        this.form.baseParams.file = field.getValue();
+        
+        var params = {};
+        params.custompath=this.TV.getCustomPath()||'';
+        params.formdata = Ext.util.JSON.encode(Ext.getCmp('modx-panel-resource').getForm().getValues()||{});
+        
+        this.form.submit({
+            waitMsg: 'Uploading...',
+            params:params,
+            success: function(fp, o){
+                var value = o.result.message;
+                this.TV.setValue(value);
+                this.fireEvent('onFileUploadSuccess',o.result);
+            }
+            ,failure: function(fp, o) { 
+                Ext.Msg.alert('Error', _('mixedimage.err_save_resource'));
+            }
+            ,scope:this
+        });
+    }
+});
+Ext.reg('mixedimage-fileform',mixedimage.fileform);
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+mixedimage.trigger = function(config){
+    config = config||{};
+    
+    config.triggerWidth=config.triggerWidth||30;
+    config.triggerConfig=this.getTriggerConfig(config);
+    config.width=(config.width||350)+config.triggerConfig.rightOffset;
+    
+    Ext.applyIf(config,{
+        
+    });
+    mixedimage.trigger.superclass.constructor.call(this,config);
+};
+Ext.extend(mixedimage.trigger,Ext.form.TriggerField,{
+    getTriggerConfig: function(config){
+        var btn_remove = config.removeFile?_('mixedimage.trigger_remove'):_('mixedimage.trigger_clear');
+        var __triggerConfig={
+            tag: 'span',
+            cls: 'x-field-combo-btns',
+            cn: [
+                {tag: 'div', cls: 'x-form-trigger x-field-trigger0-class', trigger: 'clear', title: btn_remove},
+                {tag: 'div', cls: 'x-form-trigger x-field-trigger1-class', trigger: 'manager', title: _('mixedimage.trigger_from_file_manager')},
+                {tag: 'div', cls: 'x-form-trigger x-field-trigger2-class', trigger: 'pc', title: _('mixedimage.trigger_from_desktop')}
+            ]
+        };
+        var triggerConfig = config.triggerConfig||{};
+        triggerConfig.cn = triggerConfig.cn||[];
+        triggerConfig.rightOffset=0;
+        
+        triggerConfig.cn = __triggerConfig.cn.concat(triggerConfig.cn);
+        Ext.applyIf(triggerConfig,__triggerConfig);
+
+        for(var i=triggerConfig.cn.length-1;i>=0;i--){
+            if(!triggerConfig.cn.hasOwnProperty(i))continue;
+            var width = triggerConfig.cn[i].width||config.triggerWidth;
+            var style = 'right: '+triggerConfig.rightOffset+'px !important;';
+            style += 'width:'+width+'px;';
+            triggerConfig.cn[i].style=style;
+            triggerConfig.rightOffset += width+2;
+        }
+
+        return triggerConfig;
+    }
+    ,onTriggerClick: function(event, el){
+        // Проверяем какой триггер нажат.
+        f=this['handleTrigger__'+el.getAttribute('trigger')];
+        if(typeof(f)=='function')f.call(this,this,el);
+        if(typeof(f)=='object'&&typeof(f.fn)=='function'){
+            f.fn.call(f.scope||this,this,el);
+        }
+    }
+    ,handleTrigger__clear:function(field,el){
+    	this.clearField();
+    }
+    ,handleTrigger__manager:function(field,el){
+    	var parent = Ext.get('mixedimage_media_container'+this.tvId);
+        var elems = parent.select(".x-form-file-trigger").elements; 
+        elems[0].click();
+    }
+    ,handleTrigger__pc:function(field,el){
+    	Ext.get('mixedimage_desktop'+this.tvId+'-file').dom.click();
+    }
+    ,saveValue: function(value){  
+        Ext.getCmp('mixedimage_input'+this.tvId).setValue(value); 
+        Ext.get('tv'+this.tvId).dom.value = value;
+        Ext.get('mixedimage'+this.tvId).dom.value = value;
+        MODx.fireResourceFormChange(); 
+        this.updateView();
+    }
+    ,updateView: function(){   
+        var value = Ext.get('tv'+this.tvId).dom.value;
+
+        if(this.showPreview === true){
+            var d = Ext.get('tv-image-preview-'+this.tvId);
+            if (Ext.isEmpty(value)) {
+                d.update('');
+            } else {
+                d.update('<img src="'+MODx.config.connectors_url+'system/phpthumb.php?w=200&h=100&f=png&src='+value+'&source='+this.source+'" alt="" />');
+            }
+        } 
+
+    }
+    ,clearField: function(){  
+        var value = Ext.get('tv'+this.tvId).dom.value;
+
+        if(this.ctx_path){
+            value = this.ctx_path+value;
+        }
+
+        if(this.removeFile){
+            Ext.Ajax.request({
+                url: MODx.config.assets_url+'components/mixedimage/connector.php',
+                success: function(data){                                
+                    Ext.Msg.alert('Remove', _('mixedimage.success_removed'));
+                }
+                ,failure: function(data) {
+                    Ext.Msg.alert('Error', _('mixedimage.error_remove'));                                
+                    console.log(data);
+                }
+                ,params: { value: value, action: 'removeFile' }
+            });
+        } 
+        Ext.getCmp('mixedimage_input'+this.tvId).setValue(''); 
+        Ext.get('tv'+this.tvId).dom.value = '';
+        Ext.get('mixedimage'+this.tvId).dom.value = '';
+
+        MODx.fireResourceFormChange(); 
+        this.updateView();
+    }
+});
+Ext.reg('mixedimage-trigger',mixedimage.trigger);

--- a/assets/components/mixedimage/js/mgr/mixedimage.js
+++ b/assets/components/mixedimage/js/mgr/mixedimage.js
@@ -203,6 +203,8 @@ mixedimage.trigger = function(config){
     config.triggerWidth=config.triggerWidth||30;
     config.triggerConfig=this.getTriggerConfig(config);
     config.width=(config.width||350)+config.triggerConfig.rightOffset;
+    config.style=config.style||{};
+    config.style.paddingRight=config.triggerConfig.rightOffset+'px';
     
     Ext.applyIf(config,{
         


### PR DESCRIPTION
 - Rewrite extjs part for extending and overriding by another components.
- Triggers now may configured by triggerConfig.
- Triggers handlers may extending or overriding.
- input width now depended by triggers count and its width.
- in css now not needed triggers width and positions
- add ability to set custom upload path by another components or by extending or overriding
- uploader now send all resource-panel fields in processor and may used to get upload path by placeholders or in snippet

----------------------------------
- Переписана вся extjs часть для возможности использования Ext.extend и Ext.override
- Триггеров теперь может быть сколько угодно, им можно задавать свою ширину и обработчики при вызове, расширении или переопределении.
- Ширина поля теперь зависит от количества триггеров и их ширины. Нет необходимости прописывать их в css.
- Добавлена возможность загрузки в заранее определённый путь, который может быть установлен другими компонентами.
- При загрузке на сервер теперь отправляются все поля с текущей формы ресурса, что открывает больше возможностей для генерации пути загрузки.