### PR TITLE
fix(mixedimage): TV preview after reload in MODX 3 (#35)

### DIFF
--- a/assets/components/mixedimage/js/mgr/mixedimage.js
+++ b/assets/components/mixedimage/js/mgr/mixedimage.js
@@ -1,5 +1,58 @@
 mixedimage = {};
 
+mixedimage.isPreviewEnabled = function (showPreview) {
+    return showPreview === true || showPreview === 'true' || showPreview === 1 || showPreview === '1';
+};
+
+mixedimage.getFileExtensionInfo = function (value) {
+    var ext = value.split('.').pop();
+    var mime_type;
+    var isVideo = false;
+
+    if (ext === 'mp4') {
+        mime_type = 'video/mp4';
+        isVideo = true;
+    } else if (ext === 'ogg') {
+        mime_type = 'video/ogg';
+        isVideo = true;
+    }
+
+    return {
+        ext: ext,
+        mime_type: mime_type,
+        isVideo: isVideo
+    };
+};
+
+mixedimage.buildPreviewContent = function (config, value) {
+    if (Ext.isEmpty(value)) {
+        return '';
+    }
+
+    var fileInfo = mixedimage.getFileExtensionInfo(value);
+    var path = config.ctx_path || '';
+
+    if (fileInfo.isVideo) {
+        return '<video controls><source src="../' + path + value + '" type="' + fileInfo.mime_type + '"></video>';
+    }
+
+    return '<img src="' + MODx.config.connectors_url + 'system/phpthumb.php?w=200&h=100&f=png&src='
+        + value + '&source=' + config.source + '" alt="" />';
+};
+
+mixedimage.updatePreviewElement = function (tvId, config, value) {
+    if (!mixedimage.isPreviewEnabled(config.showPreview)) {
+        return;
+    }
+
+    var preview = Ext.get('tv-image-preview-' + tvId);
+    if (!preview) {
+        return;
+    }
+
+    preview.update(mixedimage.buildPreviewContent(config, value));
+};
+
 mixedimage.panel = function (config) {
     config = config || {};
 
@@ -22,6 +75,14 @@ mixedimage.panel = function (config) {
 
     mixedimage.panel.superclass.constructor.call(this, config);
 
+    this.on('afterrender', function () {
+        mixedimage.updatePreviewElement(this.tvId, {
+            showPreview: this.showPreview,
+            ctx_path: this.ctx_path,
+            source: this.source
+        }, this.value);
+    }, this);
+
     Ext.onReady(function () { this.loadFileForm(); }, this);
 
     this.on('onFileUploadSuccess', this.onFileUploadSuccess, this);
@@ -35,8 +96,8 @@ Ext.extend(mixedimage.panel, Ext.Container, {
 
         if (config.value?.trim()) {
             const lastSlashIndex = config.value.lastIndexOf('/');
-            config.openPath = lastSlashIndex !== -1 
-                ? config.value.substring(0, lastSlashIndex) 
+            config.openPath = lastSlashIndex !== -1
+                ? config.value.substring(0, lastSlashIndex)
                 : '';
         }
 
@@ -117,63 +178,12 @@ Ext.extend(mixedimage.panel, Ext.Container, {
         this.preview = this.preview || Ext.get('tv-image-preview-' + this.tvId);
         return this.preview;
     }
-    , getExtension: function (value) {
-        var ext = value.split('.').pop();
-        var isVideo = false;
-
-        if (ext == 'mp4') {
-            var mime_type = 'video/mp4';
-            isVideo = true;
-        }
-        if (ext == 'ogg') {
-            var mime_type = 'video/ogg';
-            isVideo = true;
-        }
-
-        return {
-            ext: ext,
-            mime_type: mime_type,
-            isVideo: isVideo
-        }
-    }
     , updatePreview: function (value) {
-        if (this.showPreview === true) {
-            var d = this.getPreview();
-            var content = '';
-
-            if (!Ext.isEmpty(value)) {
-
-                var file_info = this.getExtension(value);
-
-                if (file_info.isVideo) {
-
-                    if (this.ctx_path) {
-                        var path = this.ctx_path;
-                    } else {
-                        var path = '';
-                    }
-
-                    this.previewTpl = new Ext.XTemplate('<tpl for=".">'
-                        + '<video controls>'
-                        + '<source src="../' + path + value + '" type="' + file_info.mime_type + '">'
-                        + '</video>'
-                        + '</tpl>', {
-                        compiled: true
-                    });
-
-                } else {
-                    this.previewTpl = new Ext.XTemplate('<tpl for=".">'
-                        + '<img src="' + MODx.config.connectors_url + 'system/phpthumb.php?w={width}&h={height}&f=png&src={value}&source=' + this.source + '" alt="" />'
-                        + '</tpl>', {
-                        compiled: true
-                    });
-                }
-
-                content = this.previewTpl.apply({ width: 200, height: 100, value: value });
-
-            }
-            d.update(content);
-        }
+        mixedimage.updatePreviewElement(this.tvId, {
+            showPreview: this.showPreview,
+            ctx_path: this.ctx_path,
+            source: this.source
+        }, value);
     }
     , loadFileForm: function () {
         this.uploadFormInputId = 'mixedimage_fileform' + this.tvId;
@@ -524,37 +534,21 @@ Ext.extend(mixedimage.trigger, Ext.form.TriggerField, {
                 listeners: {
                     success: {
                         fn: function () {
-                            this.setValue(''); 
+                            this.setValue('');
                             this.fireEvent('change', this);
                             MODx.msg.alert('Success', _('mixedimage.success_removed'));
                         }, scope: this
                     }
                 }
-            }); 
+            });
 
         } else {
-            this.setValue(''); 
+            this.setValue('');
             this.fireEvent('change', this);
         }
-    } 
+    }
     , getExtension: function (value) {
-        var ext = value.split('.').pop();
-        var isVideo = false;
-
-        if (ext == 'mp4') {
-            var mime_type = 'video/mp4';
-            isVideo = true;
-        }
-        if (ext == 'ogg') {
-            var mime_type = 'video/ogg';
-            isVideo = true;
-        }
-
-        return {
-            ext: ext,
-            mime_type: mime_type,
-            isVideo: isVideo
-        }
+        return mixedimage.getFileExtensionInfo(value);
     }
     , getFromUrl: function (btn, e) {
 
@@ -695,7 +689,7 @@ Ext.extend(mixedimage.trigger, Ext.form.TriggerField, {
 
                         let crop_options_config = {}
 
-                        if (field.crop_options) { 
+                        if (field.crop_options) {
                             crop_options_config = Object.fromEntries(field.crop_options.split(',').map(i => i.split(':')));
                         }
 
@@ -703,7 +697,7 @@ Ext.extend(mixedimage.trigger, Ext.form.TriggerField, {
                             ...crop_options_default,
                             ...crop_options_config
                         }
- 
+
                         cropper = new Cropper(image, crop_options);
                     }
                     , hide: function () {
@@ -731,43 +725,13 @@ Ext.extend(mixedimage.trigger, Ext.form.TriggerField, {
         this.updatePreview(value);
     }
     , updatePreview: function (value) {
-        if (this.showPreview === true) {
-            var d = this.getPreview();
-            var content = '';
+        mixedimage.updatePreviewElement(this.tvId, {
+            showPreview: this.showPreview,
+            ctx_path: this.ctx_path,
+            source: this.source
+        }, value);
 
-            if (!Ext.isEmpty(value)) {
-
-                var file_info = this.getExtension(value);
-
-                if (file_info.isVideo) {
-
-                    if (this.ctx_path) {
-                        var path = this.ctx_path;
-                    } else {
-                        var path = '';
-                    }
-
-                    this.previewTpl = new Ext.XTemplate('<tpl for=".">'
-                        + '<video controls>'
-                        + '<source src="../' + path + value + '" type="' + file_info.mime_type + '">'
-                        + '</video>'
-                        + '</tpl>', {
-                        compiled: true
-                    });
-
-                } else {
-                    this.previewTpl = new Ext.XTemplate('<tpl for=".">'
-                        + '<img src="' + MODx.config.connectors_url + 'system/phpthumb.php?w={width}&h={height}&f=png&src={value}&source=' + this.source + '" alt="" />'
-                        + '</tpl>', {
-                        compiled: true
-                    });
-                }
-
-                content = this.previewTpl.apply({ width: 200, height: 100, value: value });
-
-            }
-            d.update(content);
-
+        if (mixedimage.isPreviewEnabled(this.showPreview)) {
             MODx.fireResourceFormChange();
         }
     }

--- a/core/components/mixedimage/elements/tv/input/mixedimage.class.php
+++ b/core/components/mixedimage/elements/tv/input/mixedimage.class.php
@@ -1,116 +1,140 @@
 <?php
+
 if (!class_exists('MixedImageInputRender')) {
-	class MixedImageInputRender extends modTemplateVarInputRender
-	{
+    class MixedImageInputRender extends modTemplateVarInputRender
+    {
+        public function getTemplate()
+        {
+            return $this->modx->getOption('core_path') . 'components/mixedimage/elements/tv/input/tpl/mixedimage.tpl';
+        }
 
-		public function getTemplate()
-		{
-			return $this->modx->getOption('core_path') . 'components/mixedimage/elements/tv/input/tpl/mixedimage.tpl';
-		}
+        public function process($value, array $params = array())
+        {
+            $this->modx->regClientCSS($this->modx->getOption('assets_url') . 'components/mixedimage/lib/cropper/cropper.min.css');
+            $this->modx->regClientCSS($this->modx->getOption('assets_url') . 'components/mixedimage/css/mgr/mixedimage.css');
 
-		public function process($value, array $params = array())
-		{
-			$this->modx->regClientCSS($this->modx->getOption('assets_url') . 'components/mixedimage/lib/cropper/cropper.min.css');
-			$this->modx->regClientCSS($this->modx->getOption('assets_url') . 'components/mixedimage/css/mgr/mixedimage.css');
+            $this->modx->regClientStartupScript($this->modx->getOption('assets_url') . 'components/mixedimage/lib/cropper/cropper.min.js');
+            $this->modx->regClientStartupScript($this->modx->getOption('assets_url') . 'components/mixedimage/js/mgr/mixedimage.js');
+            // Set assets path
+            $this->setPlaceholder('assets', $this->modx->getOption('assets_url') . 'components/mixedimage/');
 
-			$this->modx->regClientStartupScript($this->modx->getOption('assets_url') . 'components/mixedimage/lib/cropper/cropper.min.js');
-			$this->modx->regClientStartupScript($this->modx->getOption('assets_url') . 'components/mixedimage/js/mgr/mixedimage.js');
-			// Set assets path
-			$this->setPlaceholder('assets', $this->modx->getOption('assets_url') . 'components/mixedimage/');
+            $this->modx->lexicon->load('mixedimage');
 
-			$this->modx->lexicon->load('mixedimage');
+            $this->setPlaceholder('res_id', $this->modx->resource->get('id'));
+            $this->setPlaceholder('ms_id', $this->tv->source);
+            $this->setPlaceholder('jsonlex', json_encode($this->modx->lexicon->fetch('mixedimage.', true)));
 
-			$this->setPlaceholder('res_id', $this->modx->resource->get('id'));
-			$this->setPlaceholder('ms_id', $this->tv->source);
-			$this->setPlaceholder('jsonlex', json_encode($this->modx->lexicon->fetch('mixedimage.', true)));
+            // Resource Alias
+            $resource_alias = ($this->modx->resource->get('alias')) ? $this->modx->resource->get('alias') : '';
+            $this->setPlaceholder('res_alias', $resource_alias);
 
-			// Resource Alias
-			$resource_alias = ($this->modx->resource->get('alias')) ? $this->modx->resource->get('alias') : '';
-			$this->setPlaceholder('res_alias', $resource_alias);
+            // Parent ID
+            $parent = $this->modx->resource->getOne('Parent');
+            $parent_id = ($parent) ? $parent->get('id') : 0;
+            $this->setPlaceholder('p_id', $parent_id);
 
-			// Parent ID
-			$parent = $this->modx->resource->getOne('Parent');
-			$parent_id = ($parent) ? $parent->get('id') : 0;
-			$this->setPlaceholder('p_id', $parent_id);
+            // Parent Alias
+            $parent_alias = ($parent) ? $parent->get('alias') : '';
+            $this->setPlaceholder('p_alias', $parent_alias);
 
-			// Parent Alias
-			$parent_alias = ($parent) ? $parent->get('alias') : '';
-			$this->setPlaceholder('p_alias', $parent_alias);
+            // Longwinded method to get tv_id to work with MIGX
+            #$this->setPlaceholder('tv_id',$this->tv->get('id'));
+            $rootTv = $this->modx->getObject('modTemplateVar', array(
+                'name' => $this->tv->get('name')
+            ));
+            $this->setPlaceholder('tv_id', $rootTv->get('id'));
 
-			// Longwinded method to get tv_id to work with MIGX
-			#$this->setPlaceholder('tv_id',$this->tv->get('id'));
-			$rootTv = $this->modx->getObject('modTemplateVar', array(
-				'name' => $this->tv->get('name')
-			));
-			$this->setPlaceholder('tv_id', $rootTv->get('id'));
+            $opts = unserialize($rootTv->input_properties);
+            $this->setPlaceholder('prefixFilename', $this->toJsBoolean($opts['prefixFilename'] ?? false));
+            $this->setPlaceholder('showPreview', $this->toJsBoolean($opts['showPreview'] ?? true));
+            $this->setPlaceholder('showValue', $this->toJsBoolean($opts['showValue'] ?? false));
+            $this->setPlaceholder('removeFile', $this->toJsBoolean($opts['removeFile'] ?? false));
+            $this->setPlaceholder('connectors_url', $this->modx->getOption('connectors_url', null, MODX_CONNECTORS_URL));
+            $this->setPlaceholder('onlyEdit', $this->modx->getOption('mixedimage.check_resid'));
+            $this->setPlaceholder('openPath', $this->parsePlaceholders($opts['path']));
+            $this->setPlaceholder('triggerlist', $opts['triggerlist'] ?: 'clear,manager,pc');
+            $this->setPlaceholder('crop_width', $opts['crop_width']);
+            $this->setPlaceholder('crop_height', $opts['crop_height']);
+            $this->setPlaceholder('crop_ratio', $opts['crop_ratio']);
+            $this->setPlaceholder('crop_suffix', $opts['crop_suffix']);
+            $this->setPlaceholder('crop_options', $opts['crop_options']);
 
-			$opts = unserialize($rootTv->input_properties);
-			$this->setPlaceholder('prefixFilename', ($opts['prefixFilename'] == $this->modx->lexicon('yes') ? 'true' : 'false'));
-			$this->setPlaceholder('showPreview', ($opts['showPreview'] == $this->modx->lexicon('yes') ? 'true' : 'false'));
-			$this->setPlaceholder('showValue', (($opts['showValue'] ?? '') === $this->modx->lexicon('yes') ? 'true' : 'false'));
-			$this->setPlaceholder('removeFile', ($opts['removeFile'] == $this->modx->lexicon('yes') ? 'true' : 'false'));
-			$this->setPlaceholder('onlyEdit', $this->modx->getOption('mixedimage.check_resid'));
-			$this->setPlaceholder('openPath', $this->parsePlaceholders($opts['path']));
-			$this->setPlaceholder('triggerlist', $opts['triggerlist'] ?: 'clear,manager,pc');
-			$this->setPlaceholder('crop_width', $opts['crop_width']);
-			$this->setPlaceholder('crop_height', $opts['crop_height']);
-			$this->setPlaceholder('crop_ratio', $opts['crop_ratio']);
-			$this->setPlaceholder('crop_suffix', $opts['crop_suffix']);
-			$this->setPlaceholder('crop_options', $opts['crop_options']);
+            $tv = $this->tv;
 
-			$tv = $this->tv;
+            $context = ($this->modx->resource->get('context_key')) ? $this->modx->resource->get('context_key') : 'web';
+            $this->setPlaceholder('context', $context);
 
-			$context = ($this->modx->resource->get('context_key')) ? $this->modx->resource->get('context_key') : 'web';
-			$this->setPlaceholder('context', $context);
+            $this->source = $tv->getSource($context);
+            $source_properties = $this->source->getPropertyList();
+            if (($source_properties['basePath'] != '')) {
+                $source_path = $source_properties['basePath'];
+            } else {
+                $source_path = '';
+            }
+            $this->setPlaceholder('source_path', $source_path);
 
-			$this->source = $tv->getSource($context);
-			$source_properties = $this->source->getPropertyList();
-			if (($source_properties['basePath'] != '')) {
-				$source_path = $source_properties['basePath'];
-			} else {
-				$source_path = '';
-			}
-			$this->setPlaceholder('source_path', $source_path);
+            // get base path from source
+            $this->source->initialize();
+            $basePath = $this->source->getBasePath();
 
-			// get base path from source		
-			$this->source->initialize();
-			$basePath = $this->source->getBasePath();
+            // get mime types
+            $video_mime_array = array('video/mp4', 'video/ogg', 'video/mpeg');
+            $current_mime = '';
+            if (!empty($value)) {
+                $fullPath = $basePath . $value;
+                if (is_file($fullPath)) {
+                    $current_mime = mime_content_type($fullPath);
+                }
+            }
 
-			// get mime types
-			$video_mime_array = array('video/mp4', 'video/ogg', 'video/mpeg');
-			$current_mime = mime_content_type($basePath . $value);
+            $this->setPlaceholder('current_mime', $current_mime);
 
-			$this->setPlaceholder('current_mime', $current_mime);
+            if (in_array($current_mime, $video_mime_array)) {
+                $this->setPlaceholder('isVideo', true);
+            } else {
+                $this->setPlaceholder('isVideo', false);
+            }
 
-			if (in_array($current_mime, $video_mime_array)) {
-				$this->setPlaceholder('isVideo', true);
-			} else {
-				$this->setPlaceholder('isVideo', false);
-			}
+            // set MIME params
+            if (isset($params['MIME'])) {
+                $MIME = $params['MIME'];
+            } else {
+                $MIME = '';
+            };
+            $this->setPlaceholder('MIME_TYPES', json_encode($MIME));
+        }
 
-			// set MIME params
-			if (isset($params['MIME'])) {
-				$MIME = $params['MIME'];
-			} else {
-				$MIME = '';
-			};
-			$this->setPlaceholder('MIME_TYPES', json_encode($MIME));
-		}
+        public function getLexiconTopics()
+        {
+            return array('mixedimage:default');
+        }
 
-		public function getLexiconTopics()
-		{
-			return array('mixedimage:default');
-		}
+        private function isYesOption($value)
+        {
+            if ($value === true || $value === 1 || $value === '1') {
+                return true;
+            }
 
-		private function parsePlaceholders($str)
-		{
-			$bits = [
-				'{id}' => $this->modx->resource->get('id'),
-				'{pid}' => $this->modx->resource->get('parent')
-			];
+            $normalized = strtolower((string)$value);
 
-			return str_replace(array_keys($bits), $bits, $str);
-		}
-	}
+            return in_array($normalized, ['yes', 'true', 'on'], true)
+                || (string)$value === (string)$this->modx->lexicon('yes');
+        }
+
+        private function toJsBoolean($value)
+        {
+            return $this->isYesOption($value) ? 'true' : 'false';
+        }
+
+        private function parsePlaceholders($str)
+        {
+            $bits = [
+                '{id}' => $this->modx->resource->get('id'),
+                '{pid}' => $this->modx->resource->get('parent')
+            ];
+
+            return str_replace(array_keys($bits), $bits, $str);
+        }
+    }
 }
 return 'MixedImageInputRender';

--- a/core/components/mixedimage/elements/tv/input/tpl/mixedimage.tpl
+++ b/core/components/mixedimage/elements/tv/input/tpl/mixedimage.tpl
@@ -1,25 +1,25 @@
-<input type="hidden" id="tv{$tv->id}" name="tv{$tv->id}" value="{$tv->value|escape}" /> 
+<input type="hidden" id="tv{$tv->id}" name="tv{$tv->id}" value="{$tv->value|escape}" />
 <div id="mixedimage{$tv->id}" class="mixedimage"></div>
 
 {if $showPreview === "true"}
 	<div id="tv-image-preview-{$tv->id}" class="modx-tv-image-preview">
-		{if $isVideo} 
+		{if $isVideo}
 		    {if $tv->value}
 			    <video controls>
-				  <source src="../{$source_path}{$tv->value}" type="{$current_mime}"> 
+				  <source src="../{$source_path}{$tv->value}" type="{$current_mime}">
 					Your browser does not support the video tag.
-				</video> 
+				</video>
 			{/if}
 		{else}
 		    {if $tv->value}
-				<img src="{$_config.connectors_url}system/phpthumb.php?w=300&h=300&aoe=0&far=0&src={$tv->value}&source={$tv->source}" alt="" />
+				<img src="{$connectors_url}system/phpthumb.php?w=300&h=300&aoe=0&far=0&src={$tv->value|escape:'url'}&source={$ms_id}" alt="" />
 			{/if}
-		{/if} 
+		{/if}
 	</div>
 {/if}
 
 <script type="text/javascript">
- 
+
 	mixedimage{$tv->id} = MODx.load{literal}({
 		{/literal}
 		xtype: 'mixedimage-panel'
@@ -36,7 +36,7 @@
 		,acceptedMIMEtypes: {$MIME_TYPES}
 		,prefixFilename: {$prefixFilename}
 		,triggerlist: '{$triggerlist}'
-		,source: '{$tv->source}'
+		,source: {$ms_id}
 		,showPreview: {$showPreview}
 		,removeFile: {$removeFile}
 		,ctx_path: '{$source_path}'
@@ -53,7 +53,7 @@
 	});
 	{/literal}
 	var field = mixedimage{$tv->id}
-	MODx.makeDroppable(field, function(v){  
+	MODx.makeDroppable(field, function(v){
 		var newValue = v.replace('{$source_path}', '');
 		field.setValue(newValue);
 		field.fireEvent('select',{ relativeUrl:newValue });


### PR DESCRIPTION
После сохранения ресурса и перезагрузки страницы в MODX 3 превью mixedImage пропадало, хотя путь к файлу в TV оставался. PR закрывает [#35](https://github.com/webinmd/mixedimage/issues/35).

## Зачем

В MODX 3 boolean-опции TV (`showPreview` и др.) хранятся как `1`/`0` через `modx-combo-boolean`. Старый код сравнивал их только с `lexicon('yes')`. В tpl блок превью не попадал в DOM, в JS `showPreview` становился `false`.

Даже при корректном SSR-превью JS не вызывал `updatePreview` при загрузке страницы. Превью обновлялось только после upload/crop/browser select.

В tpl phpThumb брал `{$_config.connectors_url}` и `{$tv->source}`. В MODX 3 manager Smarty эти значения часто пустые или неверные.

## Что сделано

### PHP — `mixedimage.class.php`

- `isYesOption()` / `toJsBoolean()` — нормализация boolean для MODX 2 и 3 (`1`, `yes`, `true`, lexicon).
- Placeholder `connectors_url` из `$modx->getOption('connectors_url')` вместо Smarty `$_config`.
- `mime_content_type()` только если файл существует (без warning на пустом value).
- PSR-12: табы заменены на пробелы (phpcbf).

### Tpl — `mixedimage.tpl`

- phpThumb: `{$connectors_url}`, `source={$ms_id}`, `src` с `escape:'url'`.
- JS config: `source: {$ms_id}` вместо строки из `$tv->source`.

### JS — `mixedimage.js`

- Хелперы: `isPreviewEnabled`, `getFileExtensionInfo`, `buildPreviewContent`, `updatePreviewElement`.
- Panel вызывает превью на `afterrender` с текущим `value`.
- Panel и trigger делегируют в один хелпер вместо двух копий `updatePreview`.

## UX

Поведение upload/crop/clear не менялось. Меняется только восстановление превью после reload и корректность SSR-картинки.

## Scope

Ветка содержит только изменения для #35. Не затрагивает crop (#31) и remove/replace (#17).

## На ревью

- Reload ресурса с сохранённым изображением в MODX 3.
- TV с `showPreview = Да` и default `1` из combo-boolean.
- Видео-превью (mp4/ogg) после reload.
- MODX 2.8: boolean через lexicon('yes') по-прежнему работает.

Fixes #35