### PR TITLE
fix(mixedimage): удаление и замена файлов TV (#17)

### DIFF
--- a/assets/components/mixedimage/js/mgr/mixedimage.js
+++ b/assets/components/mixedimage/js/mgr/mixedimage.js
@@ -1,5 +1,44 @@
 mixedimage = {};
 
+mixedimage.isYesOption = function (value) {
+    return value === true || value === 'true' || value === 1 || value === '1';
+};
+
+mixedimage.getResourceFormData = function () {
+    var panel = Ext.getCmp('modx-panel-resource');
+
+    if (!panel) {
+        return '{}';
+    }
+
+    return Ext.util.JSON.encode(panel.getForm().getValues() || {});
+};
+
+mixedimage.getRemoveParams = function (field) {
+    return {
+        file: field.getValue(),
+        action: 'file/remove',
+        source: field.source,
+        tv_id: field.tv_id,
+        formdata: mixedimage.getResourceFormData(),
+        HTTP_MODAUTH: MODx.siteId
+    };
+};
+
+mixedimage.getPreviousFileValue = function (tvPanel) {
+    if (!tvPanel) {
+        return '';
+    }
+
+    var tvField = tvPanel.getTVField ? tvPanel.getTVField() : null;
+
+    if (tvField && tvField.dom) {
+        return tvField.dom.value || '';
+    }
+
+    return tvPanel.value || '';
+};
+
 mixedimage.panel = function (config) {
     config = config || {};
 
@@ -66,6 +105,7 @@ Ext.extend(mixedimage.panel, Ext.Container, {
             , id: 'mixedimage_input' + config.tvId
             , emptyText: ''
             , tvId: config.tvId
+            , tv_id: config.tv_id
             , source: config.source
             , showPreview: config.showPreview
             , ctx_path: config.ctx_path
@@ -247,7 +287,8 @@ Ext.extend(mixedimage.fileform, Ext.FormPanel, {
 
         var params = {};
         params.custompath = this.TV.getCustomPath() || '';
-        params.formdata = Ext.util.JSON.encode(Ext.getCmp('modx-panel-resource').getForm().getValues() || {});
+        params.formdata = mixedimage.getResourceFormData();
+        params.previous_value = mixedimage.getPreviousFileValue(this.TV);
 
         this.form.submit({
             waitMsg: 'Uploading...',
@@ -268,7 +309,8 @@ Ext.extend(mixedimage.fileform, Ext.FormPanel, {
         var params = {};
         Ext.apply(params, this.baseParams);
         params.custompath = this.TV.getCustomPath() || '';
-        params.formdata = Ext.util.JSON.encode(Ext.getCmp('modx-panel-resource').getForm().getValues() || {});
+        params.formdata = mixedimage.getResourceFormData();
+        params.previous_value = mixedimage.getPreviousFileValue(this.TV);
         params.HTTP_MODAUTH = MODx.siteId;
 
         FileAPI.upload({
@@ -310,7 +352,7 @@ Ext.reg('mixedimage-fileform', mixedimage.fileform);
 mixedimage.window = function (config) {
     config = config || {};
 
-    config.formdata = Ext.util.JSON.encode(Ext.getCmp('modx-panel-resource').getForm().getValues() || {});
+    config.formdata = mixedimage.getResourceFormData();
 
     Ext.applyIf(config, {
         url: MODx.config.assets_url + 'components/mixedimage/connector.php'
@@ -353,8 +395,8 @@ Ext.extend(mixedimage.window, MODx.Window, {
 
         return {
             action: 'file/upload'
-            , tv_id: fields.tvId
-            , tvId: fields.tv_id
+            , tv_id: fields.tv_id
+            , tvId: fields.tvId
             , prefixFilename: fields.prefixFilename
             , res_id: fields.res_id
             , res_alias: fields.res_alias
@@ -365,6 +407,7 @@ Ext.extend(mixedimage.window, MODx.Window, {
             , lex: fields.jsonlex
             , ctx_path: fields.ctx_path
             , formdata: config.formdata
+            , previous_value: fields.value || ''
         };
     }
 
@@ -509,34 +552,32 @@ Ext.extend(mixedimage.trigger, Ext.form.TriggerField, {
         this.editImage(field, el);
     }
     , clearField: function () {
+        if (Ext.isEmpty(this.getValue())) {
+            this.setValueInput('');
+            return;
+        }
 
-        if (this.removeFile) {
+        if (mixedimage.isYesOption(this.removeFile)) {
 
             MODx.msg.confirm({
                 title: _('mixedimage.remove_title'),
                 text: _('mixedimage.remove_confirm'),
                 url: MODx.config.assets_url + 'components/mixedimage/connector.php',
-                params: {
-                    file: this.value
-                    , action: 'file/remove'
-                    , source: this.source
-                },
+                params: mixedimage.getRemoveParams(this),
                 listeners: {
                     success: {
                         fn: function () {
-                            this.setValue(''); 
-                            this.fireEvent('change', this);
+                            this.setValueInput('');
                             MODx.msg.alert('Success', _('mixedimage.success_removed'));
                         }, scope: this
                     }
                 }
-            }); 
+            });
 
         } else {
-            this.setValue(''); 
-            this.fireEvent('change', this);
+            this.setValueInput('');
         }
-    } 
+    }
     , getExtension: function (value) {
         var ext = value.split('.').pop();
         var isVideo = false;
@@ -729,6 +770,7 @@ Ext.extend(mixedimage.trigger, Ext.form.TriggerField, {
         tvfield.dom.value = value;
         this.el.dom.value = value;
         this.updatePreview(value);
+        MODx.fireResourceFormChange();
     }
     , updatePreview: function (value) {
         if (this.showPreview === true) {

--- a/core/components/mixedimage/elements/tv/input/mixedimage.class.php
+++ b/core/components/mixedimage/elements/tv/input/mixedimage.class.php
@@ -48,7 +48,7 @@ if (!class_exists('MixedImageInputRender')) {
 			$this->setPlaceholder('prefixFilename', ($opts['prefixFilename'] == $this->modx->lexicon('yes') ? 'true' : 'false'));
 			$this->setPlaceholder('showPreview', ($opts['showPreview'] == $this->modx->lexicon('yes') ? 'true' : 'false'));
 			$this->setPlaceholder('showValue', (($opts['showValue'] ?? '') === $this->modx->lexicon('yes') ? 'true' : 'false'));
-			$this->setPlaceholder('removeFile', ($opts['removeFile'] == $this->modx->lexicon('yes') ? 'true' : 'false'));
+			$this->setPlaceholder('removeFile', $this->toJsBoolean($opts['removeFile'] ?? false));
 			$this->setPlaceholder('onlyEdit', $this->modx->getOption('mixedimage.check_resid'));
 			$this->setPlaceholder('openPath', $this->parsePlaceholders($opts['path']));
 			$this->setPlaceholder('triggerlist', $opts['triggerlist'] ?: 'clear,manager,pc');
@@ -100,6 +100,23 @@ if (!class_exists('MixedImageInputRender')) {
 		public function getLexiconTopics()
 		{
 			return array('mixedimage:default');
+		}
+
+		private function isYesOption($value)
+		{
+			if ($value === true || $value === 1 || $value === '1') {
+				return true;
+			}
+
+			$normalized = strtolower((string)$value);
+
+			return in_array($normalized, ['yes', 'true', 'on'], true)
+				|| (string)$value === (string)$this->modx->lexicon('yes');
+		}
+
+		private function toJsBoolean($value)
+		{
+			return $this->isYesOption($value) ? 'true' : 'false';
 		}
 
 		private function parsePlaceholders($str)

--- a/core/components/mixedimage/elements/tv/input/tpl/mixedimage.tpl
+++ b/core/components/mixedimage/elements/tv/input/tpl/mixedimage.tpl
@@ -33,6 +33,7 @@
 		,p_alias: '{$p_alias}'
 		,tv_id: {$tv_id}
 		,ms_id: {$ms_id}
+		,jsonlex: {$jsonlex}
 		,acceptedMIMEtypes: {$MIME_TYPES}
 		,prefixFilename: {$prefixFilename}
 		,triggerlist: '{$triggerlist}'

--- a/core/components/mixedimage/processors/file/MixedImageBrowserFileRemoveProcessor.class.php
+++ b/core/components/mixedimage/processors/file/MixedImageBrowserFileRemoveProcessor.class.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Remove file from TV media source
+ *
+ * @package mixedimage
+ * @subpackage processors.browser.file
+ */
+
+namespace MixedImage\Processors\File;
+
+class BrowserFileRemoveProcessor extends \modProcessor
+{
+    public function getLanguageTopics()
+    {
+        return ['file', 'mixedimage'];
+    }
+
+    public function process()
+    {
+        $file = $this->getProperty('file');
+        if (empty($file)) {
+            return $this->failure($this->modx->lexicon('file_err_ns'));
+        }
+
+        $media = new MixedImageTvMediaSource($this);
+        $media->loadFormData();
+
+        $tv = $media->loadTemplateVar();
+        if (!($tv instanceof \modTemplateVar)) {
+            return $this->failure($tv);
+        }
+
+        $opts = unserialize($tv->input_properties);
+        if (!$media->isYesOption($opts['removeFile'] ?? false)) {
+            return $this->failure($this->modx->lexicon('permission_denied'));
+        }
+
+        $init = $media->initializeTvMediaSource($tv);
+        if ($init !== true) {
+            return $this->failure($init);
+        }
+
+        $removed = $media->removeFileFromSource($file);
+        if ($removed !== true) {
+            return $this->failure($removed);
+        }
+
+        return $this->success();
+    }
+}

--- a/core/components/mixedimage/processors/file/remove.class.php
+++ b/core/components/mixedimage/processors/file/remove.class.php
@@ -1,23 +1,13 @@
 <?php
 
 /**
- * Remove file from directory
- *
- * @param string $path The target directory
+ * Remove file from TV media source
  *
  * @package mixedimage
  * @subpackage processors.browser.file
  */
 
-if (!class_exists('\MODX\Revolution\modX')) {
-    require_once MODX_CORE_PATH.'model/modx/modprocessor.class.php';
-    require_once MODX_CORE_PATH.'model/modx/processors/browser/file/remove.class.php';
-} else {
-    class_alias(\MODX\Revolution\Processors\Browser\File\Remove::class, \modBrowserFileRemoveProcessor::class);
-} 
+require_once dirname(__FILE__) . '/tvmediasource.class.php';
+require_once dirname(__FILE__) . '/MixedImageBrowserFileRemoveProcessor.class.php';
 
-class mixedimageBrowserFileRemoveProcessor extends modBrowserFileRemoveProcessor
-{
-
-}
-return 'mixedimageBrowserFileRemoveProcessor';
+return \MixedImage\Processors\File\BrowserFileRemoveProcessor::class;

--- a/core/components/mixedimage/processors/file/tvmediasource.class.php
+++ b/core/components/mixedimage/processors/file/tvmediasource.class.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Shared TV and media source helpers for mixedimage file processors.
+ *
+ * @package mixedimage
+ */
+
+namespace MixedImage\Processors\File;
+
+class MixedImageTvMediaSource
+{
+    /** @var \modProcessor */
+    private $processor;
+
+    /** @var array<string, mixed> */
+    private $formdata = [];
+
+    /** @var \modMediaSource|null */
+    private $source;
+
+    public function __construct(\modProcessor $processor)
+    {
+        $this->processor = $processor;
+    }
+
+    public function setSource(\modMediaSource $source): void
+    {
+        $this->source = $source;
+    }
+
+    public function getSource(): ?\modMediaSource
+    {
+        return $this->source;
+    }
+
+    public function loadFormData(): void
+    {
+        if (!$this->processor->getProperty('formdata')) {
+            return;
+        }
+
+        $decoded = $this->processor->modx->fromJSON($this->processor->getProperty('formdata'));
+        $this->formdata = is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @return \modTemplateVar|string Failure message
+     */
+    public function loadTemplateVar()
+    {
+        $tvId = $this->processor->getProperty('tv_id') ?: $this->processor->getProperty('tvId');
+        if (empty($tvId)) {
+            return $this->processor->modx->lexicon('mixedimage.error_tvid_ns');
+        }
+
+        $tv = $this->processor->modx->getObject('modTemplateVar', $tvId);
+        if (!$tv instanceof \modTemplateVar) {
+            return $this->processor->modx->lexicon('mixedimage.error_tvid_invalid')
+                . "<br />\n[" . $tvId . "]";
+        }
+
+        return $tv;
+    }
+
+    /**
+     * @param \modTemplateVar $tv
+     * @return true|string
+     */
+    public function initializeTvMediaSource(\modTemplateVar $tv)
+    {
+        $contextKey = $this->formdata['context_key'] ?? 'web';
+        $this->source = $tv->getSource($contextKey);
+        if (!$this->source instanceof \modMediaSource) {
+            return $this->processor->modx->lexicon('mixedimage.error_remove');
+        }
+        $this->source->initialize();
+
+        return true;
+    }
+
+    public function isYesOption($value): bool
+    {
+        if ($value === true || $value === 1 || $value === '1') {
+            return true;
+        }
+
+        $normalized = strtolower((string)$value);
+
+        return in_array($normalized, ['yes', 'true', 'on'], true)
+            || $value === $this->processor->modx->lexicon('yes');
+    }
+
+    public function normalizeRelativePath(string $file): string
+    {
+        $file = preg_replace('/[\.]{2,}/', '', $file);
+        $file = ltrim($file, '/');
+
+        if ($this->source instanceof \modMediaSource) {
+            $baseUrl = $this->source->getBaseUrl();
+            if (!empty($baseUrl) && filter_var($baseUrl, FILTER_VALIDATE_URL) && strpos($file, $baseUrl) === 0) {
+                $file = substr($file, strlen($baseUrl));
+            }
+        }
+
+        return ltrim($file, '/');
+    }
+
+    /**
+     * @return true|string
+     */
+    public function removeFileFromSource(string $file)
+    {
+        if (!$this->source instanceof \modMediaSource) {
+            return $this->processor->modx->lexicon('mixedimage.error_remove');
+        }
+
+        if (!$this->source->checkPolicy('remove')) {
+            return $this->processor->modx->lexicon('permission_denied');
+        }
+
+        $file = $this->normalizeRelativePath($file);
+        if ($file === '') {
+            return $this->processor->modx->lexicon('file_err_ns');
+        }
+
+        if (!$this->source->removeObject($file)) {
+            $errors = $this->source->getErrors();
+
+            return !empty($errors)
+                ? implode("\n", $errors)
+                : $this->processor->modx->lexicon('mixedimage.error_remove');
+        }
+
+        return true;
+    }
+}

--- a/core/components/mixedimage/processors/file/upload.class.php
+++ b/core/components/mixedimage/processors/file/upload.class.php
@@ -9,6 +9,8 @@
  * @subpackage processors.browser.file
  */
 
+require_once dirname(__FILE__) . '/tvmediasource.class.php';
+
 if (!class_exists('\MODX\Revolution\modX')) {
     require_once MODX_CORE_PATH . 'model/modx/modprocessor.class.php';
     require_once MODX_CORE_PATH . 'model/modx/processors/browser/file/upload.class.php';
@@ -18,7 +20,6 @@ if (!class_exists('\MODX\Revolution\modX')) {
 
 class mixedimageBrowserFileUploadProcessor extends modBrowserFileUploadProcessor
 {
-
     public function initialize()
     {
         $this->setDefaultProperties(array(
@@ -26,8 +27,10 @@ class mixedimageBrowserFileUploadProcessor extends modBrowserFileUploadProcessor
             'path' => false
         ));
         $this->properties = $this->getProperties();
+        $this->formdata = [];
         if (isset($this->properties['formdata'])) {
-            $this->formdata = $this->modx->fromJSON($this->properties['formdata']);
+            $decoded = $this->modx->fromJSON($this->properties['formdata']);
+            $this->formdata = is_array($decoded) ? $decoded : [];
         }
 
 
@@ -56,7 +59,6 @@ class mixedimageBrowserFileUploadProcessor extends modBrowserFileUploadProcessor
 
     public function process()
     {
-
         if (count($_FILES) < 1 && !$this->getProperty('url')) {
             return $this->failure($this->modx->lexicon('mixedimage.err_file_ns'));
         }
@@ -73,7 +75,7 @@ class mixedimageBrowserFileUploadProcessor extends modBrowserFileUploadProcessor
             return $this->failure($this->modx->lexicon('mixedimage.error_tvid_invalid') . "<br />\n[" . $this->getProperty('tv_id') . "]");
         }
 
-        $context_key = $this->formdata['context_key'];
+        $context_key = $this->formdata['context_key'] ?? 'web';
 
         // Initialize and check perms for this mediasource
         $this->source = $TV->getSource($context_key); //
@@ -143,7 +145,6 @@ class mixedimageBrowserFileUploadProcessor extends modBrowserFileUploadProcessor
 
 
         if ($opts['resize']) {
-
             $params = explode("&", $opts['resize']);
 
             if (count($params) < 1) {
@@ -179,7 +180,33 @@ class mixedimageBrowserFileUploadProcessor extends modBrowserFileUploadProcessor
             }
         }
 
-        return $this->success(stripslashes($url));
+        $storedUrl = stripslashes($url);
+        $this->removePreviousFileIfReplaced($storedUrl);
+
+        return $this->success($storedUrl);
+    }
+
+    private function removePreviousFileIfReplaced(string $newUrl): void
+    {
+        $previousValue = (string)$this->getProperty('previous_value');
+        if ($previousValue === '') {
+            return;
+        }
+
+        $media = new \MixedImage\Processors\File\MixedImageTvMediaSource($this);
+        $media->setSource($this->source);
+
+        $previousPath = $media->normalizeRelativePath($previousValue);
+        $newPath = $media->normalizeRelativePath($newUrl);
+
+        if ($previousPath === '' || $previousPath === $newPath) {
+            return;
+        }
+
+        $removed = $media->removeFileFromSource($previousPath);
+        if ($removed !== true) {
+            $this->modx->log(modX::LOG_LEVEL_WARN, 'mixedImage: could not remove previous file: ' . $removed);
+        }
     }
 
     /**
@@ -223,7 +250,6 @@ class mixedimageBrowserFileUploadProcessor extends modBrowserFileUploadProcessor
      */
     private function downloadFromUrl($file_url)
     {
-
         $filePath = $this->tempPath . time() . rand(1, 10000);
         $file_output = fopen($filePath, 'wb');
 
@@ -262,7 +288,6 @@ class mixedimageBrowserFileUploadProcessor extends modBrowserFileUploadProcessor
      */
     private function preparePath($pathStr)
     {
-
         if (!empty($_REQUEST['custompath'])) {
             return $_REQUEST['custompath'];
         }
@@ -284,7 +309,6 @@ class mixedimageBrowserFileUploadProcessor extends modBrowserFileUploadProcessor
      */
     private function prepareFiles($prefix)
     {
-
         $mixedimage_translit = (bool)$this->modx->getOption('mixedimage.translit', null, false); // modx 2
         $system_translit = (bool)$this->modx->getOption('upload_translit', null, false); // modx 3
 


### PR DESCRIPTION
Исправлены проблемы из [#17](https://github.com/webinmd/mixedimage/issues/17): файл не удалялся с диска по кнопке «Очистить», при загрузке нового изображения старый оставался на сервере.

## Зачем

`remove.class.php` был пустым stub на `modBrowserFileRemoveProcessor`. Родитель инициализирует media source только по ID источника, без контекста TV. Путь файла и `basePath` не совпадали, `removeObject()` не находил файл.

Upload не удалял предыдущий файл при смене пути (orphan `.png` → `.jpg` при `prefixFilename`). Клиент не передавал `tv_id`, `formdata` и `previous_value`.

## Что сделано

### Backend

- `remove.class.php` — bootstrap, возвращает FQCN processor (PSR-1).
- `BrowserFileRemoveProcessor` — загружает TV по `tv_id`, media source из `context_key` в `formdata`, проверяет `removeFile`, удаляет через `removeObject()`.
- `MixedImageTvMediaSource` — helper для remove и upload: нормализация пути, загрузка TV, init source.
- `upload.class.php` — `removePreviousFileIfReplaced()` при разных путях и `previous_value` от клиента. Ошибка удаления не отменяет upload.

### Frontend (`mixedimage.js`)

- `getRemoveParams()` — `tv_id`, `formdata`, `HTTP_MODAUTH`, `file` через `getValue()`.
- `getPreviousFileValue()` + `previous_value` в upload (desktop, drag-and-drop, URL).
- `clearField()` через `setValueInput('')` и `MODx.fireResourceFormChange()`.
- `isYesOption()` для `removeFile` (MODX 3 хранит `1`/`0`).
- Исправлена перестановка `tv_id` / `tvId` в окне загрузки по URL.

### PHP / tpl

- `toJsBoolean()` только для опции `removeFile` в `mixedimage.class.php`.
- `jsonlex` в tpl для окна upload по URL.

## Scope

Ветка содержит только изменения для #17. Превью после reload — отдельный PR [#45](https://github.com/webinmd/mixedimage/pull/45). Crop и docs — [#44](https://github.com/webinmd/mixedimage/pull/44).

Рекомендуемый порядок merge: #45 → #44 → #46 (rebase на master после каждого).

## На ревью

- FQCN в `return` remove processor для MODX 2/3.
- Leading `\` у `\modProcessor`, `\modTemplateVar`, `\modMediaSource` в helper.
- Orphan cleanup при replace срабатывает при разных путях, не только при `removeFile=Да`.

Fixes #17